### PR TITLE
re #8 Updated finder.ex to replace is_regex that is deprecated

### DIFF
--- a/lib/finder.ex
+++ b/lib/finder.ex
@@ -168,8 +168,6 @@ defmodule Finder do
         Enum.filter(files, &(String.ends_with?(&1, endings)))
     end
 
-    
-
     #--- not yet implemented functionality ---
     # Implement if you like to do :)
 


### PR DESCRIPTION
Updated finder.ex to replace is_regex that is deprecated
