### PR TITLE
re #10 fixing travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ otp_release:
     - R16B
    
 before_install:
-    - git clone git://github.com/elixir-lang/elixir --depth 1
-    - make -C elixir
+    - git clone https://github.com/elixir-lang/elixir
+    - cd elixir && git checkout v0.12.5 && make && cd ..
 
 before_script:
     - "export PATH=`pwd`/elixir/bin:$PATH"


### PR DESCRIPTION
Fixing Travis build that will fail because of changes in Elixir that is looking for Rb17 in their deps. You can do it this way or you can of course opt to test Finder against RB17 which is already in Travis.
